### PR TITLE
Download images and duplicate tag bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ### Basic
 
+1. Set your blog's feed to **Full** in your Blogger.com dashboard: **Settings | Other | Allow Blog Feed**
 1. Get posts in JSON format from your blog using `<your blog>/feeds/posts/default?alt=json&max-results=10000` and save it to some file (eg. `data.json`)
 2. `$ npm install blogger2ghost -g`
 2. `$ blogger2ghost -i data.json > ghost.json`

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -124,7 +124,7 @@ module.exports = function(json, options, extend) {
         }, post);
     }).filter(id) : [];
 
-    var tagIds = {};
+    var tagIds = {}, tagSlugs = {};
     var tags = json.feed.category ? json.feed.category.map(function(category, i) {
         var name = convertTag(category.term);
 
@@ -134,10 +134,18 @@ module.exports = function(json, options, extend) {
 
         tagIds[name] = i;
 
+        var slug = snakeCase(unidecode(name));
+
+        if (tagSlugs.hasOwnProperty(slug)) {
+            // prevent duplicate slugs
+            return null
+        }
+        tagSlugs[slug] = i;
+
         return {
             id: i,
             name: name,
-            slug: snakeCase(unidecode(name)),
+            slug: slug,
             description: ''
         };
     }).filter(id) : [];
@@ -149,7 +157,8 @@ module.exports = function(json, options, extend) {
 
         return post.category.map(function(category) {
             var term = convertTag(category.term);
-            var tagId = tagIds[term];
+            var slug = snakeCase(unidecode(term));
+            var tagId = tagSlugs[slug]; // Lookup by slug to normalize tags
 
             if (!is.defined(tagId)) {
                 console.error(term + ' doesn\'t have a tag associated to it!');

--- a/lib/download.js
+++ b/lib/download.js
@@ -8,7 +8,7 @@ module.exports = function(folder, images, limit, callback) {
     async.eachLimit(images, limit, function(image, cb) {
         var download = new Download();
 
-        download.get(image, folder);
+        download.get(image.url, folder);
         download.run(function(err) {
             if (err) {
                 console.error(err);


### PR DESCRIPTION
The download images feature is failing in the latest code, due to an object being passed to download.get when it is expecting a URL string. This pull request fixes the issue.

Also, I added a step in the instructions to remind people to set their Blogger.com feed to "Full" before exporting. That tripped me up when I imported my blog to Ghost only to view the new blog and realize all I had was the first paragraph of each post, with jump links back to my old blog.