### PR TITLE
Add option to leave post contents in HTML format

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function main() {
         .option('-l, --download-limit <connections number>', 'Concurrent connections limit, default: 5')
         .option('-t, --remove-tables', 'Remove tables from posts')
         .option('-s --strip-diacritics', 'Strip diacritics from tags')
+        .option('-h --raw-html', 'Don\'t convert HTML to Markdown')
         .parse(process.argv);
 
     if (!program.input) {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -65,7 +65,7 @@ module.exports = function(json, options, extend) {
         }
 
         var slug = snakeCase(unidecode(title)),
-            markdown = tomd(html, options),
+            markdown = options.rawHtml ? html : tomd(html, options),
             published = Date.parse(post.published['$t']);
 
         // prevent duplicate slugs (suffix post index if slug exists)


### PR DESCRIPTION
The HTML to Markdown conversion was really mangling some of my posts. It was deleting lots of images and links for some reason, sometimes leaving empty [ ] in their place. I didn't really need my old posts being converted to Markdown, plus my posts had divs with CSS classes that determined visual style, and links with JavaScript onClick handlers specified, and the Markdown conversion was stripping all that out.

I've added a command line option (-h --raw-html) to leave the post content in HTML format. I've tested this with my blog extract of over 300 posts that contain lots of images, videos, divs, etc. and it imported into Ghost without issue and displays perfectly.

I think this feature will be helpful for people like myself that are looking to move their blog to Ghost with minimal effort, while being able to take full advantage of Ghost features like Markdown for any new posts they create.